### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -16,7 +16,7 @@ jobs:
         ref: ${{ github.ref }}
     
     - name: Build and push tagged image to Docker Hub
-      uses: elgohr/Publish-Docker-Github-Action@2.9     
+      uses: elgohr/Publish-Docker-Github-Action@v5     
       with:
         name: tomfrench/liquidityburner
         username: ${{ secrets.DOCKER_USERNAME }}
@@ -24,7 +24,7 @@ jobs:
         tag_names: true
     
     - name: Push image with latest tag to Docker Hub
-      uses: elgohr/Publish-Docker-Github-Action@2.9
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: tomfrench/liquidityburner
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore